### PR TITLE
Fix the bug that calculation result of deployment frequency is not accurate.

### DIFF
--- a/backend/src/services/common/DeploymentFrequency.ts
+++ b/backend/src/services/common/DeploymentFrequency.ts
@@ -50,15 +50,29 @@ function mapDeploymentPassedItems(
   return result;
 }
 
+// TODO：校验部署时间是否在startTime和endTime内
 export function calculateDeploymentFrequency(
   deployTimes: DeployTimes[],
   startTime: number,
   endTime: number
 ): Pair<DeploymentFrequencyOfPipeline[], AvgDeploymentFrequency> {
   const timePeriod = calculateWorkDaysBetween(startTime, endTime);
+  // const actualDeployTimes: DeployTimes[] = deployTimes.map(
+  //   (deployTimesItem) => {
+  //     deployTimesItem.passed.filter(
+  //       (deployInfoItem) =>
+  //         new Date(deployInfoItem.jobFinishTime) <= new Date(endTime)
+  //     )
+  //     return deployTimesItem;
+  //   }
+  // );
   const deployFrequencyOfEachPipeline: DeploymentFrequencyModel[] = deployTimes.map(
     (item) => {
-      const passedDeployTimes = item.passed.length;
+      const passedDeployTimes = item.passed.filter(
+        (deployInfoItem) =>
+          new Date(deployInfoItem.jobFinishTime).getTime <=
+            new Date(endTime).getTime || deployInfoItem.jobFinishTime == "time"
+      ).length;
       if (passedDeployTimes == 0 || timePeriod == 0) {
         return new DeploymentFrequencyModel(
           item.pipelineName,

--- a/backend/src/services/common/DeploymentFrequency.ts
+++ b/backend/src/services/common/DeploymentFrequency.ts
@@ -61,8 +61,7 @@ export function calculateDeploymentFrequency(
     (item) => {
       const passedDeployTimes = item.passed.filter(
         (deployInfoItem) =>
-          new Date(deployInfoItem.jobFinishTime).getTime() <= endTime ||
-          deployInfoItem.jobFinishTime == "time"
+          new Date(deployInfoItem.jobFinishTime).getTime() <= endTime
       ).length;
       if (passedDeployTimes == 0 || timePeriod == 0) {
         return new DeploymentFrequencyModel(

--- a/backend/src/services/common/DeploymentFrequency.ts
+++ b/backend/src/services/common/DeploymentFrequency.ts
@@ -57,22 +57,14 @@ export function calculateDeploymentFrequency(
   endTime: number
 ): Pair<DeploymentFrequencyOfPipeline[], AvgDeploymentFrequency> {
   const timePeriod = calculateWorkDaysBetween(startTime, endTime);
-  // const actualDeployTimes: DeployTimes[] = deployTimes.map(
-  //   (deployTimesItem) => {
-  //     deployTimesItem.passed.filter(
-  //       (deployInfoItem) =>
-  //         new Date(deployInfoItem.jobFinishTime) <= new Date(endTime)
-  //     )
-  //     return deployTimesItem;
-  //   }
-  // );
   const deployFrequencyOfEachPipeline: DeploymentFrequencyModel[] = deployTimes.map(
     (item) => {
-      const passedDeployTimes = item.passed.filter(
+      const itemPassed: DeployInfo[] = item.passed.filter(
         (deployInfoItem) =>
           new Date(deployInfoItem.jobFinishTime).getTime <=
             new Date(endTime).getTime || deployInfoItem.jobFinishTime == "time"
-      ).length;
+      );
+      const passedDeployTimes = itemPassed.length;
       if (passedDeployTimes == 0 || timePeriod == 0) {
         return new DeploymentFrequencyModel(
           item.pipelineName,
@@ -85,7 +77,7 @@ export function calculateDeploymentFrequency(
         item.pipelineName,
         item.pipelineStep,
         passedDeployTimes / timePeriod,
-        item.passed
+        itemPassed
       );
     }
   );

--- a/backend/src/services/common/DeploymentFrequency.ts
+++ b/backend/src/services/common/DeploymentFrequency.ts
@@ -50,7 +50,6 @@ function mapDeploymentPassedItems(
   return result;
 }
 
-// TODO：校验部署时间是否在startTime和endTime内
 export function calculateDeploymentFrequency(
   deployTimes: DeployTimes[],
   startTime: number,
@@ -87,11 +86,6 @@ export function calculateDeploymentFrequency(
 
   const deploymentFrequencyOfPipelines: DeploymentFrequencyOfPipeline[] = deployFrequencyOfEachPipeline.map(
     (item) =>
-      // const itemPassed: DeployInfo[] = item.passed.filter(
-      //   (deployInfoItem) =>
-      //     new Date(deployInfoItem.jobFinishTime).getTime <=
-      //       new Date(endTime).getTime || deployInfoItem.jobFinishTime == "time"
-      // );
       new DeploymentFrequencyOfPipeline(
         item.name,
         item.step,

--- a/backend/src/services/common/DeploymentFrequency.ts
+++ b/backend/src/services/common/DeploymentFrequency.ts
@@ -59,12 +59,11 @@ export function calculateDeploymentFrequency(
   const timePeriod = calculateWorkDaysBetween(startTime, endTime);
   const deployFrequencyOfEachPipeline: DeploymentFrequencyModel[] = deployTimes.map(
     (item) => {
-      const itemPassed: DeployInfo[] = item.passed.filter(
+      const passedDeployTimes = item.passed.filter(
         (deployInfoItem) =>
-          new Date(deployInfoItem.jobFinishTime).getTime <=
-            new Date(endTime).getTime || deployInfoItem.jobFinishTime == "time"
-      );
-      const passedDeployTimes = itemPassed.length;
+          new Date(deployInfoItem.jobFinishTime).getTime() <= endTime ||
+          deployInfoItem.jobFinishTime == "time"
+      ).length;
       if (passedDeployTimes == 0 || timePeriod == 0) {
         return new DeploymentFrequencyModel(
           item.pipelineName,
@@ -77,7 +76,7 @@ export function calculateDeploymentFrequency(
         item.pipelineName,
         item.pipelineStep,
         passedDeployTimes / timePeriod,
-        itemPassed
+        item.passed
       );
     }
   );
@@ -89,11 +88,20 @@ export function calculateDeploymentFrequency(
 
   const deploymentFrequencyOfPipelines: DeploymentFrequencyOfPipeline[] = deployFrequencyOfEachPipeline.map(
     (item) =>
+      // const itemPassed: DeployInfo[] = item.passed.filter(
+      //   (deployInfoItem) =>
+      //     new Date(deployInfoItem.jobFinishTime).getTime <=
+      //       new Date(endTime).getTime || deployInfoItem.jobFinishTime == "time"
+      // );
       new DeploymentFrequencyOfPipeline(
         item.name,
         item.step,
         item.value,
-        mapDeploymentPassedItems(item.passed)
+        mapDeploymentPassedItems(
+          item.passed.filter(
+            (item) => new Date(item.jobFinishTime).getTime() <= endTime
+          )
+        )
       )
   );
 

--- a/backend/tests/controller/GenerateReportController.test.ts
+++ b/backend/tests/controller/GenerateReportController.test.ts
@@ -9,7 +9,7 @@ chai.use(chaiHttp);
 chai.should();
 
 describe.skip("GenerateReporter", () => {
-  it("should return 200 and report data when  post data correct", async () => {
+  it("should return 200 and report data when post data correct", async () => {
     const response = await chai
       .request(app)
       .post("/generateReporter")

--- a/backend/tests/services/common/DeploymentFrequency.test.ts
+++ b/backend/tests/services/common/DeploymentFrequency.test.ts
@@ -17,12 +17,26 @@ import {
 
 describe("DeploymentFrequency", () => {
   const deployInfo = new DeployInfo("time", "time", "time", "commit", "passed");
-  const deployinfoOutOfTime = new DeployInfo(
+  const deployInfoOutOfTime = new DeployInfo(
     "time",
     "time",
     "2020-4-15",
     "commit",
     "passed"
+  );
+  const deployInfoPassedWithRealTime = new DeployInfo(
+    "2020-5-11",
+    "2020-5-11",
+    "2020-5-11",
+    "commit",
+    "passed"
+  );
+  const deployInfoFailedWithRealTime = new DeployInfo(
+    "2020-5-11",
+    "2020-5-11",
+    "2020-5-11",
+    "commit",
+    "failed"
   );
   const deployTimes5 = new DeployTimes(
     "id",
@@ -42,26 +56,54 @@ describe("DeploymentFrequency", () => {
     new Array(10).fill(deployInfo),
     []
   );
-  const deploytimes6 = new DeployTimes(
+  const deployTimes6 = new DeployTimes(
     "id",
     "name6",
     "step",
-    new Array(6).fill(deployInfo, 0, 4).fill(deployinfoOutOfTime, 5),
+    new Array(6).fill(deployInfo, 0, 4).fill(deployInfoOutOfTime, 5),
     []
   );
-  const deploytimes3 = new DeployTimes(
+  const deployTimes3 = new DeployTimes(
     "id",
     "name3",
     "step",
-    new Array(3).fill(DeployInfo),
+    new Array(3).fill(deployInfo),
     []
   );
-  const deploytimes2 = new DeployTimes(
+  const deployTimes2 = new DeployTimes(
     "id",
     "name2",
     "step",
-    new Array(2).fill(DeployInfo),
+    new Array(2).fill(deployInfo),
     []
+  );
+  const deployTimes8 = new DeployTimes(
+    "id",
+    "name8",
+    "step",
+    new Array(8).fill(deployInfoPassedWithRealTime),
+    []
+  );
+  const deployTimes9 = new DeployTimes(
+    "id",
+    "name9",
+    "step",
+    [],
+    new Array(9).fill(deployInfoFailedWithRealTime)
+  );
+  const deployTimes12 = new DeployTimes(
+    "id",
+    "name12",
+    "step",
+    new Array(6).fill(deployInfoPassedWithRealTime),
+    new Array(6).fill(deployInfoFailedWithRealTime)
+  );
+  const deployTimes18 = new DeployTimes(
+    "id",
+    "name18",
+    "step",
+    new Array(10).fill(deployInfoPassedWithRealTime),
+    new Array(8).fill(deployInfoFailedWithRealTime)
   );
 
   before(async function () {
@@ -71,103 +113,223 @@ describe("DeploymentFrequency", () => {
     await loadHolidayList(2020);
   });
 
-  it("should return deployment frequency", async () => {
-    const expectFiveTimesDeployment: DeploymentFrequencyOfPipeline[] = [
-      new DeploymentFrequencyOfPipeline("name5", "step", 5, []),
-    ];
-    const expectTwoPipelineDeploymentInFiveDays: DeploymentFrequencyOfPipeline[] = [
-      new DeploymentFrequencyOfPipeline("name5", "step", 1, []),
-      new DeploymentFrequencyOfPipeline("name10", "step", 2, []),
-    ];
-    const fiveTimesAvgDeploymentFrequency = new AvgDeploymentFrequency(5);
-    const expectAvgDeploymentInFiveDays = new AvgDeploymentFrequency(1.5);
+  describe("should return correct deployment frequency", () => {
+    it("should return 0 when have no deployment", async () => {
+      const deployTimes0: DeployTimes[] = [];
 
-    expect(
-      calculateDeploymentFrequency(
-        [deployTimes5],
+      expect(
+        calculateDeploymentFrequency(
+          deployTimes0,
+          new Date("2020-4-7").getTime(),
+          new Date("2020-4-7").getTime()
+        )
+      ).deep.equal(new Pair([], noAvgDeploymentFrequency));
+    });
+
+    it("should return 0 when time period is holiday", async () => {
+      expect(
+        calculateDeploymentFrequency(
+          [deployTimes5],
+          new Date("2020-4-5").getTime(),
+          new Date("2020-4-6").getTime()
+        )
+      ).deep.equal(new Pair(expectNoDeployment, noAvgDeploymentFrequency));
+    });
+    it("should return deployment frequency of two pipelines", async () => {
+      const expectFiveTimesDeployment: DeploymentFrequencyOfPipeline[] = [
+        new DeploymentFrequencyOfPipeline("name5", "step", 5, []),
+      ];
+      const expectTwoPipelineDeploymentInFiveDays: DeploymentFrequencyOfPipeline[] = [
+        new DeploymentFrequencyOfPipeline("name5", "step", 1, []),
+        new DeploymentFrequencyOfPipeline("name10", "step", 2, []),
+      ];
+      const fiveTimesAvgDeploymentFrequency = new AvgDeploymentFrequency(5);
+      const expectAvgDeploymentInFiveDays = new AvgDeploymentFrequency(1.5);
+
+      expect(
+        calculateDeploymentFrequency(
+          [deployTimes5],
+          new Date("2020-4-7").getTime(),
+          new Date("2020-4-7").getTime()
+        )
+      ).deep.equal(
+        new Pair(expectFiveTimesDeployment, fiveTimesAvgDeploymentFrequency)
+      );
+
+      expect(
+        calculateDeploymentFrequency(
+          [deployTimes5, deployTimes10],
+          new Date("2020-5-11").getTime(),
+          new Date("2020-5-17").getTime()
+        )
+      ).deep.equal(
+        new Pair(
+          expectTwoPipelineDeploymentInFiveDays,
+          expectAvgDeploymentInFiveDays
+        )
+      );
+    });
+
+    it("should return correct deployment frequency when contains over three pipelines", async () => {
+      const expectAvgDeploymentInOneDay = new AvgDeploymentFrequency(5);
+
+      const expectFourPipelineDeploymentInOneDay: DeploymentFrequencyOfPipeline[] = [
+        new DeploymentFrequencyOfPipeline("name5", "step", 5, []),
+        new DeploymentFrequencyOfPipeline("name10", "step", 10, []),
+        new DeploymentFrequencyOfPipeline("name3", "step", 3, []),
+        new DeploymentFrequencyOfPipeline("name2", "step", 2, []),
+      ];
+
+      expect(
+        calculateDeploymentFrequency(
+          [deployTimes5, deployTimes10, deployTimes3, deployTimes2],
+          new Date("2020-5-11").getTime(),
+          new Date("2020-5-11").getTime()
+        )
+      ).deep.equal(
+        new Pair(
+          expectFourPipelineDeploymentInOneDay,
+          expectAvgDeploymentInOneDay
+        )
+      );
+    });
+
+    it("should return correct deployment frequency when some deploy date not falls into the date range", async () => {
+      const expectSixTimesDeployment: DeploymentFrequencyOfPipeline[] = [
+        new DeploymentFrequencyOfPipeline("name6", "step", 5, [
+          { count: 1, date: "4/15/2020" },
+        ]),
+      ];
+      const sixTimesAvgDeploymentFrequency = new AvgDeploymentFrequency(5);
+
+      const result = calculateDeploymentFrequency(
+        [deployTimes6],
         new Date("2020-4-7").getTime(),
         new Date("2020-4-7").getTime()
-      )
-    ).deep.equal(
-      new Pair(expectFiveTimesDeployment, fiveTimesAvgDeploymentFrequency)
-    );
+      );
 
-    expect(
-      calculateDeploymentFrequency(
-        [deployTimes5, deployTimes10],
-        new Date("2020-5-11").getTime(),
-        new Date("2020-5-17").getTime()
-      )
-    ).deep.equal(
-      new Pair(
-        expectTwoPipelineDeploymentInFiveDays,
-        expectAvgDeploymentInFiveDays
-      )
-    );
+      expect(result).deep.equal(
+        new Pair(expectSixTimesDeployment, sixTimesAvgDeploymentFrequency)
+      );
+    });
   });
 
-  it("should return 0 when have no deployment", async () => {
-    const deployTimes0: DeployTimes[] = [];
+  describe("should return correct deployment passed items", () => {
+    it("should return 8 deployment passed items when 8 deployment all passed", async () => {
+      const expectAvgDeploymentInOneDay = new AvgDeploymentFrequency(8);
 
-    expect(
-      calculateDeploymentFrequency(
-        deployTimes0,
-        new Date("2020-4-7").getTime(),
-        new Date("2020-4-7").getTime()
-      )
-    ).deep.equal(new Pair([], noAvgDeploymentFrequency));
-  });
+      const expectOnePipelineDeploymentInOneDay: DeploymentFrequencyOfPipeline[] = [
+        new DeploymentFrequencyOfPipeline("name8", "step", 8, [
+          { count: 8, date: "5/11/2020" },
+        ]),
+      ];
 
-  it("should return 0 when time period is holiday", async () => {
-    expect(
-      calculateDeploymentFrequency(
-        [deployTimes5],
-        new Date("2020-4-5").getTime(),
-        new Date("2020-4-6").getTime()
-      )
-    ).deep.equal(new Pair(expectNoDeployment, noAvgDeploymentFrequency));
-  });
+      expect(
+        calculateDeploymentFrequency(
+          [deployTimes8],
+          new Date("2020-5-11").getTime(),
+          new Date("2020-5-11").getTime()
+        )
+      ).deep.equal(
+        new Pair(
+          expectOnePipelineDeploymentInOneDay,
+          expectAvgDeploymentInOneDay
+        )
+      );
+    });
 
-  it("should return correct deployment frequency when some deploy date not falls into the date range", async () => {
-    const expectSixTimesDeployment: DeploymentFrequencyOfPipeline[] = [
-      new DeploymentFrequencyOfPipeline("name6", "step", 5, [
-        { count: 1, date: "4/15/2020" },
-      ]),
-    ];
-    const sixTimesAvgDeploymentFrequency = new AvgDeploymentFrequency(5);
+    it("should return 0 deployment passed items when deployment all failed", async () => {
+      const expectAvgDeploymentInOneDay = new AvgDeploymentFrequency(0);
 
-    const result = calculateDeploymentFrequency(
-      [deploytimes6],
-      new Date("2020-4-7").getTime(),
-      new Date("2020-4-7").getTime()
-    );
+      const expectOnePipelineDeploymentInOneDay: DeploymentFrequencyOfPipeline[] = [
+        new DeploymentFrequencyOfPipeline("name9", "step", 0, []),
+      ];
 
-    expect(result).deep.equal(
-      new Pair(expectSixTimesDeployment, sixTimesAvgDeploymentFrequency)
-    );
-  });
+      expect(
+        calculateDeploymentFrequency(
+          [deployTimes9],
+          new Date("2020-5-11").getTime(),
+          new Date("2020-5-11").getTime()
+        )
+      ).deep.equal(
+        new Pair(
+          expectOnePipelineDeploymentInOneDay,
+          expectAvgDeploymentInOneDay
+        )
+      );
+    });
 
-  it("should return correct deployment frequency when contains over three pipelines", async () => {
-    const expectAvgDeploymentInOneDay = new AvgDeploymentFrequency(5);
+    it("should return 6 deployment passed items of one pipeline when 6 deployment passed and 6 deployment failed", async () => {
+      const expectAvgDeploymentInOneDay = new AvgDeploymentFrequency(6);
 
-    const expectFourPipelineDeploymentInOneDay: DeploymentFrequencyOfPipeline[] = [
-      new DeploymentFrequencyOfPipeline("name5", "step", 5, []),
-      new DeploymentFrequencyOfPipeline("name10", "step", 10, []),
-      new DeploymentFrequencyOfPipeline("name3", "step", 3, []),
-      new DeploymentFrequencyOfPipeline("name2", "step", 2, []),
-    ];
+      const expectOnePipelineDeploymentInOneDay: DeploymentFrequencyOfPipeline[] = [
+        new DeploymentFrequencyOfPipeline("name12", "step", 6, [
+          { count: 6, date: "5/11/2020" },
+        ]),
+      ];
 
-    expect(
-      calculateDeploymentFrequency(
-        [deployTimes5, deployTimes10, deploytimes3, deploytimes2],
-        new Date("2020-5-11").getTime(),
-        new Date("2020-5-11").getTime()
-      )
-    ).deep.equal(
-      new Pair(
-        expectFourPipelineDeploymentInOneDay,
-        expectAvgDeploymentInOneDay
-      )
-    );
+      expect(
+        calculateDeploymentFrequency(
+          [deployTimes12],
+          new Date("2020-5-11").getTime(),
+          new Date("2020-5-11").getTime()
+        )
+      ).deep.equal(
+        new Pair(
+          expectOnePipelineDeploymentInOneDay,
+          expectAvgDeploymentInOneDay
+        )
+      );
+    });
+
+    it("should return 8 deployment passed items of two pipelines when one pipeline all passed and another all failed", async () => {
+      const expectAvgDeploymentInOneDay = new AvgDeploymentFrequency(4);
+
+      const expectTwoPipelineDeploymentInOneDay: DeploymentFrequencyOfPipeline[] = [
+        new DeploymentFrequencyOfPipeline("name8", "step", 8, [
+          { count: 8, date: "5/11/2020" },
+        ]),
+        new DeploymentFrequencyOfPipeline("name9", "step", 0, []),
+      ];
+
+      expect(
+        calculateDeploymentFrequency(
+          [deployTimes8, deployTimes9],
+          new Date("2020-5-11").getTime(),
+          new Date("2020-5-11").getTime()
+        )
+      ).deep.equal(
+        new Pair(
+          expectTwoPipelineDeploymentInOneDay,
+          expectAvgDeploymentInOneDay
+        )
+      );
+    });
+
+    it("should return 8 deployment passed items of two pipelines when both of them contain passed and failed deployment", async () => {
+      const expectAvgDeploymentInOneDay = new AvgDeploymentFrequency(8);
+
+      const expectTwoPipelineDeploymentInOneDay: DeploymentFrequencyOfPipeline[] = [
+        new DeploymentFrequencyOfPipeline("name12", "step", 6, [
+          { count: 6, date: "5/11/2020" },
+        ]),
+        new DeploymentFrequencyOfPipeline("name18", "step", 10, [
+          { count: 10, date: "5/11/2020" },
+        ]),
+      ];
+
+      expect(
+        calculateDeploymentFrequency(
+          [deployTimes12, deployTimes18],
+          new Date("2020-5-11").getTime(),
+          new Date("2020-5-11").getTime()
+        )
+      ).deep.equal(
+        new Pair(
+          expectTwoPipelineDeploymentInOneDay,
+          expectAvgDeploymentInOneDay
+        )
+      );
+    });
   });
 });

--- a/backend/tests/services/common/DeploymentFrequency.test.ts
+++ b/backend/tests/services/common/DeploymentFrequency.test.ts
@@ -60,7 +60,7 @@ describe("DeploymentFrequency", () => {
     "id",
     "name6",
     "step",
-    new Array(6).fill(deployInfo, 0, 4).fill(deployInfoOutOfTime, 5),
+    new Array(6).fill(deployInfo, 0, 5).fill(deployInfoOutOfTime, 5, 6),
     []
   );
   const deployTimes3 = new DeployTimes(
@@ -104,6 +104,24 @@ describe("DeploymentFrequency", () => {
     "step",
     new Array(10).fill(deployInfoPassedWithRealTime),
     new Array(8).fill(deployInfoFailedWithRealTime)
+  );
+  const deployTimes20 = new DeployTimes(
+    "id",
+    "name20",
+    "step",
+    new Array(20).fill(
+      new DeployInfo("2020-5-12", "2020-5-12", "2020-5-18", "commit", "passed")
+    ),
+    []
+  );
+  const deployTimes25 = new DeployTimes(
+    "id",
+    "name25",
+    "step",
+    new Array(25).fill(
+      new DeployInfo("2020-5-12", "2020-5-12", "2020-5-14", "commit", "passed")
+    ),
+    []
   );
 
   before(async function () {
@@ -196,9 +214,7 @@ describe("DeploymentFrequency", () => {
 
     it("should return correct deployment frequency when some deploy date not falls into the date range", async () => {
       const expectSixTimesDeployment: DeploymentFrequencyOfPipeline[] = [
-        new DeploymentFrequencyOfPipeline("name6", "step", 5, [
-          { count: 1, date: "4/15/2020" },
-        ]),
+        new DeploymentFrequencyOfPipeline("name6", "step", 5, []),
       ];
       const sixTimesAvgDeploymentFrequency = new AvgDeploymentFrequency(5);
 
@@ -328,6 +344,30 @@ describe("DeploymentFrequency", () => {
         new Pair(
           expectTwoPipelineDeploymentInOneDay,
           expectAvgDeploymentInOneDay
+        )
+      );
+    });
+
+    it("should return deployment passed items of two pipelines when some deploy date not falls into the date range", async () => {
+      const expectAvgDeploymentInFiveDay = new AvgDeploymentFrequency(2.5);
+
+      const expectTwoPipelineDeploymentInFiveDay: DeploymentFrequencyOfPipeline[] = [
+        new DeploymentFrequencyOfPipeline("name20", "step", 0, []),
+        new DeploymentFrequencyOfPipeline("name25", "step", 5, [
+          { count: 25, date: "5/14/2020" },
+        ]),
+      ];
+
+      expect(
+        calculateDeploymentFrequency(
+          [deployTimes20, deployTimes25],
+          new Date("2020-5-11").getTime(),
+          new Date("2020-5-15").getTime()
+        )
+      ).deep.equal(
+        new Pair(
+          expectTwoPipelineDeploymentInFiveDay,
+          expectAvgDeploymentInFiveDay
         )
       );
     });

--- a/backend/tests/services/common/DeploymentFrequency.test.ts
+++ b/backend/tests/services/common/DeploymentFrequency.test.ts
@@ -16,11 +16,24 @@ import {
 } from "../../../src/contract/GenerateReporter/GenerateReporterResponse";
 
 describe("DeploymentFrequency", () => {
-  const deployInfo = new DeployInfo("time", "time", "time", "commit", "passed");
+  const deployInfo = new DeployInfo(
+    "2020-5-11",
+    "2020-5-11",
+    "2020-5-11",
+    "commit",
+    "passed"
+  );
+  const deployInfoForHoliday = new DeployInfo(
+    "2020-5-16",
+    "2020-5-16",
+    "2020-5-18",
+    "commit",
+    "passed"
+  );
   const deployInfoOutOfTime = new DeployInfo(
     "time",
     "time",
-    "2020-4-15",
+    "2020-5-18",
     "commit",
     "passed"
   );
@@ -43,6 +56,13 @@ describe("DeploymentFrequency", () => {
     "name5",
     "step",
     new Array(5).fill(deployInfo),
+    []
+  );
+  const deployTimes5ForHoliday = new DeployTimes(
+    "id",
+    "name5",
+    "step",
+    new Array(5).fill(deployInfoForHoliday),
     []
   );
   const expectNoDeployment: DeploymentFrequencyOfPipeline[] = [
@@ -147,19 +167,25 @@ describe("DeploymentFrequency", () => {
     it("should return 0 when time period is holiday", async () => {
       expect(
         calculateDeploymentFrequency(
-          [deployTimes5],
-          new Date("2020-4-5").getTime(),
-          new Date("2020-4-6").getTime()
+          [deployTimes5ForHoliday],
+          new Date("2020-5-16").getTime(),
+          new Date("2020-5-17").getTime()
         )
       ).deep.equal(new Pair(expectNoDeployment, noAvgDeploymentFrequency));
     });
     it("should return deployment frequency of two pipelines", async () => {
       const expectFiveTimesDeployment: DeploymentFrequencyOfPipeline[] = [
-        new DeploymentFrequencyOfPipeline("name5", "step", 5, []),
+        new DeploymentFrequencyOfPipeline("name5", "step", 5, [
+          { count: 5, date: "5/11/2020" },
+        ]),
       ];
       const expectTwoPipelineDeploymentInFiveDays: DeploymentFrequencyOfPipeline[] = [
-        new DeploymentFrequencyOfPipeline("name5", "step", 1, []),
-        new DeploymentFrequencyOfPipeline("name10", "step", 2, []),
+        new DeploymentFrequencyOfPipeline("name5", "step", 1, [
+          { count: 5, date: "5/11/2020" },
+        ]),
+        new DeploymentFrequencyOfPipeline("name10", "step", 2, [
+          { count: 10, date: "5/11/2020" },
+        ]),
       ];
       const fiveTimesAvgDeploymentFrequency = new AvgDeploymentFrequency(5);
       const expectAvgDeploymentInFiveDays = new AvgDeploymentFrequency(1.5);
@@ -167,8 +193,8 @@ describe("DeploymentFrequency", () => {
       expect(
         calculateDeploymentFrequency(
           [deployTimes5],
-          new Date("2020-4-7").getTime(),
-          new Date("2020-4-7").getTime()
+          new Date("2020-5-11").getTime(),
+          new Date("2020-5-11").getTime()
         )
       ).deep.equal(
         new Pair(expectFiveTimesDeployment, fiveTimesAvgDeploymentFrequency)
@@ -192,10 +218,18 @@ describe("DeploymentFrequency", () => {
       const expectAvgDeploymentInOneDay = new AvgDeploymentFrequency(5);
 
       const expectFourPipelineDeploymentInOneDay: DeploymentFrequencyOfPipeline[] = [
-        new DeploymentFrequencyOfPipeline("name5", "step", 5, []),
-        new DeploymentFrequencyOfPipeline("name10", "step", 10, []),
-        new DeploymentFrequencyOfPipeline("name3", "step", 3, []),
-        new DeploymentFrequencyOfPipeline("name2", "step", 2, []),
+        new DeploymentFrequencyOfPipeline("name5", "step", 5, [
+          { count: 5, date: "5/11/2020" },
+        ]),
+        new DeploymentFrequencyOfPipeline("name10", "step", 10, [
+          { count: 10, date: "5/11/2020" },
+        ]),
+        new DeploymentFrequencyOfPipeline("name3", "step", 3, [
+          { count: 3, date: "5/11/2020" },
+        ]),
+        new DeploymentFrequencyOfPipeline("name2", "step", 2, [
+          { count: 2, date: "5/11/2020" },
+        ]),
       ];
 
       expect(
@@ -214,14 +248,16 @@ describe("DeploymentFrequency", () => {
 
     it("should return correct deployment frequency when some deploy date not falls into the date range", async () => {
       const expectSixTimesDeployment: DeploymentFrequencyOfPipeline[] = [
-        new DeploymentFrequencyOfPipeline("name6", "step", 5, []),
+        new DeploymentFrequencyOfPipeline("name6", "step", 5, [
+          { count: 5, date: "5/11/2020" },
+        ]),
       ];
       const sixTimesAvgDeploymentFrequency = new AvgDeploymentFrequency(5);
 
       const result = calculateDeploymentFrequency(
         [deployTimes6],
-        new Date("2020-4-7").getTime(),
-        new Date("2020-4-7").getTime()
+        new Date("2020-5-11").getTime(),
+        new Date("2020-5-11").getTime()
       );
 
       expect(result).deep.equal(


### PR DESCRIPTION
Pair with WangWei

1. Deployments that are not within the given time period should not be included in the calculation of deployment frequency.

2.Modify some unreasonable data for test, and remove useless statements in the implementation.