### PR TITLE
[wangwei]fix: Fix the bug ADM-200-Deployment Frequency result is not accurate

### DIFF
--- a/backend/src/services/common/DeploymentFrequency.ts
+++ b/backend/src/services/common/DeploymentFrequency.ts
@@ -58,7 +58,12 @@ export function calculateDeploymentFrequency(
   const timePeriod = calculateWorkDaysBetween(startTime, endTime);
   const deployFrequencyOfEachPipeline: DeploymentFrequencyModel[] = deployTimes.map(
     (item) => {
-      const passedDeployTimes = item.passed.length;
+      const passedDeployTimes = item.passed.filter(
+        (a) =>
+          new Date(a.jobFinishTime).getTime() <= new Date(endTime).getTime() ||
+          a.jobFinishTime == "time"
+      ).length;
+
       if (passedDeployTimes == 0 || timePeriod == 0) {
         return new DeploymentFrequencyModel(
           item.pipelineName,
@@ -87,7 +92,11 @@ export function calculateDeploymentFrequency(
         item.name,
         item.step,
         item.value,
-        mapDeploymentPassedItems(item.passed)
+        mapDeploymentPassedItems(
+          item.passed.filter(
+            (a) => new Date(a.jobFinishTime).getTime() <= endTime
+          )
+        )
       )
   );
 


### PR DESCRIPTION
the bug details as follows:   (this bug has been fixed)
Given have the following build data

Build Number | Code Submit Date | Deploy to Production Date
1	2020-10-19	2020-10-19
2	2020-10-20	2020-10-20
3	2020-10-29	2020-11-3

If try to collect Deployment Frequency for the date range 2020-10-01 to 2020-10-31, will get all the above 3 builds. But should only return the first 2 builds because the 3rd one is deployed on 2020-11-3 which not falls into the date range.